### PR TITLE
fix: Add a dependency on FXML to fix a build error

### DIFF
--- a/aliyun-spring-boot-starters/aliyun-fc-spring-boot-starter/pom.xml
+++ b/aliyun-spring-boot-starters/aliyun-fc-spring-boot-starter/pom.xml
@@ -34,6 +34,12 @@
             <artifactId>gson</artifactId>
         </dependency>
 
+        <!-- OpenJFX FXML -->
+        <dependency>
+          <groupId>org.openjfx</groupId>
+          <artifactId>javafx-fxml</artifactId>
+          <version>19-ea+6</version>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>


### PR DESCRIPTION
Fix a build error due to dependency resolution failure by adding a dependency on OpenJFX FXML.
Use OpenJFX as an alternative to JavaFX to avoid licensing issues.